### PR TITLE
Fixed jumping navbar text on hover

### DIFF
--- a/general.css
+++ b/general.css
@@ -156,7 +156,7 @@ img.center {
 	font-size:80%;
 	background:#222;
 	height:0;
-	line-height:0;
+	line-height:40px;
 	overflow:hidden;
 	padding:0;
 	transition:all 0.3s;


### PR DESCRIPTION
Currently when hovering over a navigation item with a drop down menu, the text initializes above where it's expected to be and "jumps".

Result of fix:
http://cl.ly/3B3q42270o3A
