### PR TITLE
Added link-text class and applied to sponsors link

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         <br><br>
         <div class="strike">
             <span class="csh-sponsors-text">
-                Sponsors
+                <a class="link-text" href="sponsors.html">Sponsors</a>
             </span>
         </div>
         <div class="sponsor-container">

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -504,6 +504,18 @@ p{
     font-size:30px;
 }
 
+.link-text,
+.link-text:visited,
+.link-text:hover,
+.link-text:active{
+	color: #B0197E;
+	text-decoration: none;
+}
+
+.link-text:hover{
+	color: #701050;
+}
+
 .strike {
     display: block;
     text-align: center;


### PR DESCRIPTION
The sponsors link on index.html is now able to navigate you to the sponsors page. There is also now a reusable css class for purple links if anything else needs it.