### PR TITLE
Add whitespace to the bottom of the 40th chairman's letter

### DIFF
--- a/40th_chairman_letter.html
+++ b/40th_chairman_letter.html
@@ -28,18 +28,17 @@
                <p> We’ve planned a phenomenal looking weekend for everyone starting with a game of Capture the Disk the night of Friday April 15th for those who can make it in that early. After which will be trips to your garbage plate destination of choice. During the day Saturday we’ll hold tours of floor to show off our new facilities as well as behind the scenes tours of the new Gene Polisseni Center for all you hockey fans. Following all this will be a formal banquet held in the Davis Room of the Student Alumni Union at 7:00 PM Saturday. There will be a buffet of Italian food including Chicken Piccata, Tortellini, Salads, and a dessert of Tiramisu! There will be plenty of refreshments, a dance floor, and a brief speech from yours truly on the current state of Computer Science House! For those of you with small children who are looking for babysitting, we’re currently looking into renting a licensed child care facility for the night, if you’re interested in this please note this in your RSVP.</p>
                 <p>Sunday morning we’ll have one last get together / good bye in the form of a brunch back at the Davis Room before everyone heads back to their respective homes. We’ll be distributing T-Shirts specially designed for this event!</p>
                <p> I look forward to seeing those of you I know and am excited to meet those I don’t! If you have any questions at all don’t hesitate to reach out to me at chairman@csh.rit.edu.</p>
-                
+
 Sincerely,<br>
 Andrew Glaude<br>
 Computer Science House Chairman
-        
+
         <br><br>
-        
+
         <a href="http://csh.rit.edu/images/40thinviteletter.pdf" style="color:#8E0E67">Download This Letter</a>
-        
-        
-        
+
         <br><br><br class="hidden-xs">
+
     <!-- End Page Content Here -->
     </div>
         <include file="resources/templates/_footer.html"></include>

--- a/40th_chairman_letter.html
+++ b/40th_chairman_letter.html
@@ -37,9 +37,9 @@ Computer Science House Chairman
         
         <a href="http://csh.rit.edu/images/40thinviteletter.pdf" style="color:#8E0E67">Download This Letter</a>
         
-        <br><br>
         
         
+        <br><br><br class="hidden-xs">
     <!-- End Page Content Here -->
     </div>
         <include file="resources/templates/_footer.html"></include>


### PR DESCRIPTION
Nitpick, but I think it looks a lot better with a little bit more whitespace at the bottom of the page with how much whitespace we have on the left & right of the letter.

Hidden on mobile browsers as their left & right margins are much smaller.