### PR TITLE
Removed white border from .csh-btn

### DIFF
--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -618,7 +618,6 @@ h4,h3{
 
 .csh-btn{
     background-color:#B0197E;
-    border:2px solid #FFF;
     color:#FFF;
     transition: background-color .1s ease-in;
     -webkit-transition: background-color .1s ease-in;
@@ -629,13 +628,11 @@ h4,h3{
 }
 .csh-btn:hover, .csh-btn:focus{
     background-color:#861360;
-    border-color:#FFF;
     color:#FFF;
     
 }
 .csh-btn:active{
     background-color: #701050;
-    border-color:#FFF;
     color:#FFF;
 }
 .grid{


### PR DESCRIPTION
Just a small bug fix. For some reason, the .csh-btn class was applying an unnecessary white border to our custom buttons. This PR removes it.