### PR TITLE
40th Updates & Fixes

### DIFF
--- a/40th.html
+++ b/40th.html
@@ -70,7 +70,7 @@
 		  			<img src="resources/images/40th/hampton.png" alt="Hampton by Hilton" width="150px">
 		  		</div>
 		  		<div class="col-md-10">
-		  			<p>CSH has reserved a block of rooms at the Hampton Inn &amp; Suites Rochester/Henrietta for the event. The hotel has created a reservation portal for members to reserve rooms in our hotel block at a special rate. Rooms start at $99/night until March 15th or until the block is sold-out, whichever comes first.</p>
+		  			<p>CSH has reserved a block of rooms at the Hampton Inn &amp; Suites Rochester/Henrietta for the event. The hotel has created a reservation portal for members to reserve rooms in our hotel block at a special rate. Rooms start at $99/night until the block is sold out, so please reserve your room as soon as possible!</p>
 		  			<a href="https://www.google.com/maps/d/u/0/viewer?mid=zXAxVDtxnzvs.kA5WwPsTXacI" class="btn csh-btn" target="_blank"><i class="fa fa-map"></i> View Map</i></a>
 		  			<a href="http://hamptoninn.hilton.com/en/hp/groups/personalized/R/ROCHEHX-CSR-20160415/index.jhtml?WT.mc_id=POG" class="btn csh-btn" target="_blank">Reserve a room <i class="fa fa-arrow-right"></i></a>
 		  		</div>
@@ -106,7 +106,7 @@
 						<h2>Hotel Reservations Begin</h2>
 						<p>
 							<span class="timeline-date">January 10, 2016</span>
-							Hampton Inn &amp; Suites Rochester/Henrietta has created a reservation portal for members to reserve rooms in our hotel block at a special rate. Rooms start at $99/night until March 15th or until the block is sold-out, whichever comes first.
+							Hampton Inn &amp; Suites Rochester/Henrietta has created a reservation portal for members to reserve rooms in our hotel block at a special rate. Rooms start at $99/night until the block is sold out, so please reserve your room as soon as possible!
 						</p>
 						<a href="http://hamptoninn.hilton.com/en/hp/groups/personalized/R/ROCHEHX-CSR-20160415/index.jhtml?WT.mc_id=POG" class="btn csh-btn" target="_blank">Reserve a room <i class="fa fa-arrow-right"></i></a>
 					</div>

--- a/40th.html
+++ b/40th.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-    <title>CSH | 40th</title>
+    <title>CSH | 40th Anniversary</title>
     <include file="resources/templates/_header.html"></include>
 </head>
 	<link rel="stylesheet" href="resources/css/timeline.css">

--- a/40th.html
+++ b/40th.html
@@ -88,10 +88,10 @@
 						<i class="fa fa-ticket"></i>
 					</div>
 					<div class="timeline-content right">
-						<h2>Ticket Price Announced</h2>
+						<h2>Ticket Sales Begin</h2>
 						<p>
-							<span class="timeline-date">February 11, 2016</span>
-                            Tickets for the event will be going on sale very soon, and will be priced at $80. 
+							<span class="timeline-date">February 17, 2016</span>
+                            Tickets for the event are now on sale for $80 per person! Please reserve your spot by clicking the button below. You will be redirected to RIT Alumni Relations to complete your reservation.
                             <br><br>
                             <a href="https://securelb.imodules.com/s/1624/index.aspx?sid=1624&gid=1&pgid=2346&cid=3762"><button class="btn csh-btn" style="font-size:25px;">RSVP Now <i class="fa fa-arrow-right"></i></button></a>
 						</p>

--- a/resources/templates/_navbar.html
+++ b/resources/templates/_navbar.html
@@ -25,7 +25,7 @@
           <ul class="dropdown-menu">
             <li><a href="40th_chairman_letter.html">Chairman's Letter</a></li>
             <li><a href="40th_save_the_date.html">Save The Date</a></li>
-            <li><a href="40th_events.html">Events Overview</a></li>
+            <li><a href="40th_events.html">Event Overview</a></li>
             <li><a href="https://securelb.imodules.com/s/1624/index.aspx?sid=1624&gid=1&pgid=2346&cid=3762">40th Registration</a></li>
           </ul>
         </li>


### PR DESCRIPTION
This PR encompasses a few fixes and updates for the 40th anniversary section of the site:
* Elaborated on the 40th page title and fixed a typo in the navbar
* The ticket card has been updated to reflect that tickets are now on sale
* The hotel information has been updated to remove the deadline of March 15th, as Hampton Inn is still allowing reservations