### PR TITLE
Revert "Fix subdirectory resource access fixes #107"

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <title>CSH | 404</title>
-    <include file="/resources/templates/_header.html"></include>
+    <include file="resources/templates/_header.html"></include>
 </head>
 
   <body>
 
-    <include file="/resources/templates/_navbar.html"></include>
+    <include file="resources/templates/_navbar.html"></include>
 
     <!-- Main jumbotron for a primary marketing message or call to action -->
     <div class="jumbotron csh-page-header">
@@ -30,7 +30,7 @@
                     <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/t3otBjVZzT0?autoplay=1" frameborder="0" allowfullscreen></iframe>
                 </div>
             </div><!----><div class="col-xs-12 col-sm-6 col-md-6 vcenter">
-                <img src="/resources/images/jr-purple.svg" class="img-responsive" style="margin:auto">
+                <img src="resources/images/jr-purple.svg" class="img-responsive" style="margin:auto">
             <br>
             </div>
         </div>
@@ -38,12 +38,12 @@
         
     <!-- End Page Content Here -->
     </div>
-      <include file="/resources/templates/_footer.html"></include>
+      <include file="resources/templates/_footer.html"></include>
 
 
 
     <!-- Bootstrap core JavaScript
     ================================================== -->
-    <include file="/resources/templates/_coreJS.html"></include>
+    <include file="resources/templates/_coreJS.html"></include>
   </body>
 </html>


### PR DESCRIPTION
Reverts ComputerScienceHouse/CSHPublicSite#136. 

I read this wrong when I merged it - this does not supply a fix for absolute pathing, as these includes are only for when the site gets built with pyBuilder. The issue is actually with paths that are inside the included templates.