### PR TITLE
Fixes Broken CSH Image On 404 Page.

### DIFF
--- a/404.html
+++ b/404.html
@@ -30,7 +30,7 @@
                     <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/t3otBjVZzT0?autoplay=1" frameborder="0" allowfullscreen></iframe>
                 </div>
             </div><!----><div class="col-xs-12 col-sm-6 col-md-6 vcenter">
-                <img src="resources/images/jr-purple.svg" class="img-responsive" style="margin:auto">
+                <img src="/resources/images/jr-purple.svg" class="img-responsive" style="margin:auto">
             <br>
             </div>
         </div>


### PR DESCRIPTION
Fixes an issue where the CSH logo on the 404 page was not showing up because it was relatively pathed instead of absolutely pathed. 

**Before**
<img width="1280" alt="screen shot 2016-08-27 at 9 48 06 pm" src="https://cloud.githubusercontent.com/assets/3893578/18031648/fca9039e-6c9f-11e6-914e-7f3ce5dd843b.png">

**After**
<img width="1276" alt="screen shot 2016-08-27 at 9 48 58 pm" src="https://cloud.githubusercontent.com/assets/3893578/18031651/1729447c-6ca0-11e6-9ebe-93871a77a4bf.png">
