### PR TITLE
Fixes #107 - Navbar links to no longer 404 while under subdirectories 

### DIFF
--- a/resources/templates/_navbar.html
+++ b/resources/templates/_navbar.html
@@ -5,34 +5,34 @@
       <button type="button" class="navbar-toggle csh-toggle" data-toggle="collapse" data-target=".navbar-collapse">
         <i class="fa fa-bars"></i>
       </button>
-      <a class="navbar-brand" href="index.html"><img src="/resources/images/Round-with-Thin-Text.svg" class="csh-logo"></a>
+      <a class="navbar-brand" href="/index.html"><img src="/resources/images/Round-with-Thin-Text.svg" class="csh-logo"></a>
     </div>
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav pull-right">
-          <li><a href="index.html"><div class="csh-navbar-nav-shift navbarActive" page="index.html">Home</div></a></li>
+          <li><a href="/index.html"><div class="csh-navbar-nav-shift navbarActive" page="index.html">Home</div></a></li>
 
         <li class="dropdown">
-            <a href="about.html" class="dropdown-toggle disabled" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><div class="csh-navbar-nav-shift navbarActive" page="about.html,projects.html,alumni.html,eboard.html,sponsors.html">About <span class="caret"></span></div></a>
+            <a href="/about.html" class="dropdown-toggle disabled" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><div class="csh-navbar-nav-shift navbarActive" page="about.html,projects.html,alumni.html,eboard.html,sponsors.html">About <span class="caret"></span></div></a>
           <ul class="dropdown-menu">
-            <li><a href="projects.html">Projects</a></li>
-            <li><a href="alumni.html">Alumni</a></li>
-            <li><a href="eboard.html">Eboard</a></li>
-            <li><a href="sponsors.html">Sponsors</a></li>
+            <li><a href="/projects.html">Projects</a></li>
+            <li><a href="/alumni.html">Alumni</a></li>
+            <li><a href="/eboard.html">Eboard</a></li>
+            <li><a href="/sponsors.html">Sponsors</a></li>
 
           </ul>
         </li>
 
         <li class="dropdown">
-            <a href="membership.html" class="nav-dropdown-toggle dropdown-toggle disabled" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><div class="csh-navbar-nav-shift navbarActive" page="membership.html,traditions.html,tour.html,insights.html">Membership<span class="caret"></span></div></a>
+            <a href="/membership.html" class="nav-dropdown-toggle dropdown-toggle disabled" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><div class="csh-navbar-nav-shift navbarActive" page="membership.html,traditions.html,tour.html,insights.html">Membership<span class="caret"></span></div></a>
           <ul class="dropdown-menu">
-            <li><a href="traditions.html">Traditions</a></li>
-            <li><a href="tour.html">Tour</a></li>
-            <li><a href="insights.html">Insights</a></li>
+            <li><a href="/traditions.html">Traditions</a></li>
+            <li><a href="/tour.html">Tour</a></li>
+            <li><a href="/insights.html">Insights</a></li>
 
           </ul>
         </li>
 
-          <li><a href="contact.html"><div class="csh-navbar-nav-shift navbarActive" page="contact.html">Contact</div></a></li>
+          <li><a href="/contact.html"><div class="csh-navbar-nav-shift navbarActive" page="contact.html">Contact</div></a></li>
       </ul>
     </div><!--/.nav-collapse -->
   </div>


### PR DESCRIPTION
Previously, links on the navbar were relative, so trying to click a nav link from a subdirectory led to the 404 page. Adding the slash before the filename (i.e. "contact.html" -> "/contact.html") references to that specific file in the root directory, which fixes that problem. 

This fixes issue #107.