### PR TITLE
Add A Banner For House Funding

### DIFF
--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -947,7 +947,7 @@ td,th{
     color: #FFF;
     position: fixed;
     top: 0px;
-    font-size: 12px;
+    font-size: 14px;
 }
 
 .banner-padding {

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -916,3 +916,39 @@ td,th{
     
 }
 
+.banner {
+    width: 100%;
+    padding: 5px;
+    z-index: 999;
+    text-align: center;
+    background: #E11C52;
+    color: #FFF;
+    position: fixed;
+    top: 0px;
+    font-size: 12px;
+}
+
+.navbar.banner-active {
+    margin-top: 26px;
+}
+
+a.muted {
+    text-decoration: none !important;
+}
+
+.label-white {
+    background: #FFF;
+}
+
+.label-raised {
+    -webkit-box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
+    -moz-box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
+    box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
+}
+
+
+
+.color.csh-red {
+    color: #E11C52;
+}
+

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -6,6 +6,24 @@ body{
     -webkit-font-smoothing: antialiased;
 }
 
+a.muted {
+    text-decoration: none !important;
+}
+
+.label-white {
+    background: #FFF;
+}
+
+.label-raised {
+    -webkit-box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
+    -moz-box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
+    box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
+}
+
+.color.csh-red {
+    color: #E11C52;
+}
+
 @media(min-width:768px){
     body {
         padding-top: 100px;
@@ -916,6 +934,10 @@ td,th{
     
 }
 
+/*
+* Navigation Banner
+*/
+
 .banner {
     width: 100%;
     padding: 5px;
@@ -928,27 +950,16 @@ td,th{
     font-size: 12px;
 }
 
+.banner-padding {
+    padding-top: 26px;
+    display: none;
+}
+
+.banner-padding.banner-active {
+    display: block !important;
+}
+
 .navbar.banner-active {
     margin-top: 26px;
-}
-
-a.muted {
-    text-decoration: none !important;
-}
-
-.label-white {
-    background: #FFF;
-}
-
-.label-raised {
-    -webkit-box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
-    -moz-box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
-    box-shadow: 1px 1px 1px 0px rgba(170,170,170,1);
-}
-
-
-
-.color.csh-red {
-    color: #E11C52;
 }
 

--- a/resources/templates/_navbar.html
+++ b/resources/templates/_navbar.html
@@ -1,5 +1,11 @@
 <div class="desktop-hide" style="padding:30px;"></div>
-<nav class="navbar navbar-csh navbar-fixed-top">
+<div class="banner">
+    We're building a house!
+    <a href="https://www.rit.edu/development/giving/ComputerScienceHouse40" target="_blank" class="muted">
+        <span class="label label-white label-raised color csh-red">Learn More and Donate</span>
+    </a>
+</div>
+<nav class="navbar navbar-csh navbar-fixed-top banner-active">
     <div class="container">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle csh-toggle" data-toggle="collapse" data-target=".navbar-collapse">

--- a/resources/templates/_navbar.html
+++ b/resources/templates/_navbar.html
@@ -1,4 +1,5 @@
 <div class="desktop-hide" style="padding:30px;"></div>
+<div class="banner-padding banner-active"></div>
 <div class="banner">
     We're building a house!
     <a href="https://www.rit.edu/development/giving/ComputerScienceHouse40" target="_blank" class="muted">


### PR DESCRIPTION
@rswiernik, 

Adds a banner to the top of the navigation to link to our house funding information and project details.

<img width="862" alt="screen shot 2016-12-02 at 12 12 17 am" src="https://cloud.githubusercontent.com/assets/3893578/20827048/14397d70-b824-11e6-80f8-f96c17c98bd3.png">
<img width="311" alt="screen shot 2016-12-02 at 12 12 25 am" src="https://cloud.githubusercontent.com/assets/3893578/20827051/1455fbee-b824-11e6-9c39-722277e2bbb1.png">
<img width="865" alt="screen shot 2016-12-02 at 12 12 40 am" src="https://cloud.githubusercontent.com/assets/3893578/20827050/14557dd6-b824-11e6-8325-7e47a02d5f6b.png">

### Tests
1. Verify all pages have the new banner.
2. Verify the button to `Learn More and Donate` leads to RIT's beyond a dorm page
3. Verify the navigation and headers for pages are correct
  - About Us
  - Eboard
  - etc.
4. Verify navigation and header on mobile are correctly formatted