### PR TITLE
Fixes Insights Page To Include One Date Section.

### DIFF
--- a/insights.html
+++ b/insights.html
@@ -21,14 +21,6 @@
         <div class="container" style="padding: 0px 0px 0px 0px; margin-top: -30px;">
             <div class="insights-header">
                 <div class="insights-date date-title">Accepted Student Open House</div>
-                <div class="insights-date">April 9-10, 2016</div>
-                <div class="insights-date date-title">ImagineRIT Weekend</div>
-                <div class="insights-date">May 6-7, 2016</div>
-            </div>
-        </div>
-        <div class="container" style="padding: 0px 0px 0px 0px; margin-top: -30px;">
-            <div class="insights-header">
-                <div class="insights-date date-title">Accepted Student Open House</div>
                 <div class="insights-date">April 8-9, 2017</div>
                 <div class="insights-date date-title">ImagineRIT Weekend</div>
                 <div class="insights-date">May 5-6, 2017</div>


### PR DESCRIPTION
@rswiernik,

Fixes the Insights page to only have the one correct date section caused by a conflict-fix issue.
<img width="800" alt="screen shot 2016-12-02 at 12 22 32 am" src="https://cloud.githubusercontent.com/assets/3893578/20827260/b08c4e2c-b825-11e6-9457-44a61155eb40.png">

### Tests
1. Verify the insights page has one date section
2. Verify the insights page has the updated 2017 dates.
3. Verify the `Register` button is disabled
