### PR TITLE
Fixes Membership Page Spacing Error

### DIFF
--- a/membership.html
+++ b/membership.html
@@ -54,8 +54,7 @@
             <div class="row">
                 <div class="col-xs-12 col-sm-6 col-md-4 vcenter">
                     <img src="resources/images/project2.png" class="member-page-thumbnail hcenter-div">
-                </div>
-                <div class="col-xs-12 col-sm-6 col-md-8 vcenter">
+                </div><!----><div class="col-xs-12 col-sm-6 col-md-8 vcenter">
                     <h3>Member Benefits</h3>
                     <p>CSH's perks more than make up for all the work that goes into membership. All members, both on-floor and off-floor, get the following benefits:
                         <ul>


### PR DESCRIPTION
Fixes the membership spacing error caused by extra space between two div elements.

**Before**
<img width="1172" alt="screen shot 2017-09-01 at 1 18 05 pm" src="https://user-images.githubusercontent.com/3893578/29980501-0cc9e7a2-8f18-11e7-8878-79ba27a7ce01.png">

**After**
<img width="1170" alt="screen shot 2017-09-01 at 1 17 57 pm" src="https://user-images.githubusercontent.com/3893578/29980515-13605d80-8f18-11e7-89b1-5f9913469ed4.png">
