### PR TITLE
Update contact.html

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -71,7 +71,9 @@
                         Computer Science House
                     </h4>
                     <p>
-                        3999 Nathaniel Rochester Hall
+                        5000 Nathaniel Rochester Hall
+                        <br> 
+                        #3999
                         <br> 
                         Rochester, NY 14623
                     </p>


### PR DESCRIPTION
Fix CSH address, to comply with the new Post Office address format:
From 

3999 Nathaniel Rochester Hall 
Rochester, NY 14623

to

5000 Nathaniel Rochester Hall 
#3999
Rochester, NY 14623