### PR TITLE
Removes Netrek

### DIFF
--- a/traditions.html
+++ b/traditions.html
@@ -63,16 +63,6 @@
             </div>
             <div class="row">
                 <div class="col-xs-12 col-sm-6 col-md-4 vcenter">
-                    <img src="resources/images/traditions/netrek.jpg" class="traditions-page-thumbnail hcenter-div">
-                </div><!----><div class="col-xs-12 col-sm-6 col-md-8 vcenter">
-                    <h3>Netrek</h3>
-                    <p>
-                        On Friday nights throughout the year, we invade the Computer Science labs to play an old game called Netrek. In this online team-play game from the 80’s, you control a ship flying through space, conquering planets and destroying your foes with a sophisticated array of weapons and countermeasures. Superior strategy and coordination will propel your team to victory!
-                    </p>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-xs-12 col-sm-6 col-md-4 vcenter">
                     <img src="resources/images/traditions/seminar.jpg" class="traditions-page-thumbnail hcenter-div">
                 </div><!----><div class="col-xs-12 col-sm-6 col-md-8 vcenter">
                     <h3>Seminars</h3>


### PR DESCRIPTION
Removes Netrek from the Traditions page since I have _never_ heard of anyone actually playing it. Similarly, when at Insights, absolutely _nobody_ knew what it was. They thought I was talking about nethack.