### PR TITLE
Remove paper applications from How To Apply

### DIFF
--- a/membership.html
+++ b/membership.html
@@ -34,7 +34,7 @@
                     </p>
                     <h3>Current Students</h3>
                     <p>
-                        Students already enrolled at RIT can apply to join CSH at any time. The best way to apply is to visit CSH (on the third floor of Nathaniel Rochester Hall) and pick up an application from our Evaluations Director. All majors and years are accepted and members can live on or off floor.
+                        Students already enrolled at RIT can apply to join CSH at any time. Simply email evals@csh.rit.edu expressing interest in applying! Our Evaluations Director will get back to you with information and provide you with an application. We also encourage you to come visit us on the third floor of Nathaniel Rochester Hall. All majors and years can apply, and members can live on or off floor.
                     </p>
                 </div><!----><div class="col-xs-12 col-sm-6 col-md-4 vcenter">
                     <img src="resources/images/voting.jpg" class="member-page-thumbnail hcenter-div">


### PR DESCRIPTION
Also changes "accepted" to "can apply", so it no longer implies that applying means instant membership.