### PR TITLE
Various changes to site footer contents

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,10 +6,11 @@
                     <a href="/about/faq.html">FAQ</a>
                     <a href="/membership/intro-process.html">How to Apply</a>
                     <a href="https://schedule.csh.rit.edu/">RIT ScheduleMaker</a>
-                    <a href="/blog/">Blog</a>
                     <a href="https://constitution.csh.rit.edu/">Constitution</a>
                     <a href="https://github.com/computersciencehouse/"><i class="fab fa-github"></i>GitHub</a>
+                    <a href="https://medium.com/ritcsh"><i class="fab fa-medium"></i></i>Medium</a>
                     <a href="https://www.facebook.com/RITCSH/"><i class="fab fa-facebook"></i>Facebook</a>
+                    <a href="https://twitter.com/RITCSH"><i class="fab fa-twitter"></i>Twitter</a>
                     <a href="https://twitter.com/CSH_HISTORY/"><i class="fab fa-twitter"></i>@CSH_History</a>
                     <a href="https://twitter.com/OPCOMM/"><i class="fab fa-twitter"></i>@OpComm</a>
                 </div>


### PR DESCRIPTION
added link to the CSH Twitter account and Medium. Removed link to pubsite blog from footer because with the 2 additions the links wrapped to 2 lines. I removed the blog since its already linked in the header of the website and on the homepage