### PR TITLE
Various Revisions to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,6 +8,10 @@
                     <a href="https://schedule.csh.rit.edu/">RIT ScheduleMaker</a>
                     <a href="/blog/">Blog</a>
                     <a href="https://constitution.csh.rit.edu/">Constitution</a>
+                </div>
+            </div>
+            <div class = "row">
+                <div class = "col-12">
                     <a href="https://github.com/computersciencehouse/"><i class="fab fa-github"></i>GitHub</a>
                     <a href="https://medium.com/ritcsh"><i class="fab fa-medium"></i>Medium</a>
                     <a href="https://www.facebook.com/RITCSH/"><i class="fab fa-facebook"></i>Facebook</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,9 @@
                     <a href="/blog/">Blog</a>
                     <a href="https://constitution.csh.rit.edu/">Constitution</a>
                     <a href="https://github.com/computersciencehouse/"><i class="fab fa-github"></i>GitHub</a>
+                    <a href="https://medium.com/ritcsh"><i class="fab fa-medium"></i>Medium</a>
                     <a href="https://www.facebook.com/RITCSH/"><i class="fab fa-facebook"></i>Facebook</a>
+                    <a href="https://twitter.com/RITCSH/"><i class="fab fa-twitter"></i>Twitter</a>
                     <a href="https://twitter.com/CSH_HISTORY/"><i class="fab fa-twitter"></i>@CSH_History</a>
                     <a href="https://twitter.com/OPCOMM/"><i class="fab fa-twitter"></i>@OpComm</a>
                 </div>

--- a/about/eboard.html
+++ b/about/eboard.html
@@ -126,7 +126,7 @@ active: about-eboard
             </div>
             <div class="col-12 col-lg-9">
                 <h2 class="header">Research and Development</h2>
-                <h3>Nick Mosher</h3>
+                <h3>Nick Mosher &amp; Kaitlin Berryman</h3>
                 <p class="long-form">
                     R&D is responsible for organizing seminars and assisting with technical projects, with the goal of encouraging members to learn new skills and gain experience.
                 </p>


### PR DESCRIPTION
added links to CSH medium and CSH twitter to footer and added another row of links to the footer so that there is a row for navigation links and a row for social links
<img width="1331" alt="Screen Shot 2019-11-30 at 1 09 26 PM" src="https://user-images.githubusercontent.com/31291523/69904291-e5c03580-1372-11ea-9bf6-9bbf34667a05.png">
