### PR TITLE
Removed padded-gray attribute from Constant Contact

### DIFF
--- a/about/alumni.html
+++ b/about/alumni.html
@@ -141,7 +141,7 @@ active: about-alumni
             </div>
             <div class="col-4 col-lg-2">
                 <a href="http://www.constantcontact.com">
-                    <img class="rounded padded-gray" src="https://assets.csh.rit.edu/pubsite/alumni/constantcontactnew.png" alt="Constant Contact">
+                    <img class="rounded" src="https://assets.csh.rit.edu/pubsite/alumni/constantcontactnew.png" alt="Constant Contact">
                 </a>
             </div>
             <div class="col-4 col-lg-2">


### PR DESCRIPTION
Should have done this in the last commit. Removes unnecessary gray border from Constant Contact's new logo.