### PR TITLE
Fix FSL link in FAQ

### DIFF
--- a/about/faq.html
+++ b/about/faq.html
@@ -39,7 +39,7 @@ active: about-faq
                         <p>
                             No, we're a Special Interest House: a space in RIT's dorms designed for students who share common interests to live together.
                             Read more here about SIHs <a href="https://www.rit.edu/fa/housing/housing-option/special-interest-lifestyle-floors">here</a>,
-                            and more about RIT Fraternity and Sorority Life <a href="https://www.rit.edu/studentaffairs/fsl/">here</a>.
+                            and more about RIT Fraternity and Sorority Life <a href="https://campusgroups.rit.edu/fsl/about/">here</a>.
                         </p>
                     </li>
                     <li>


### PR DESCRIPTION
Hello!

This PR fixes the "Fraternity & Sorority Life" link in the FAQ. The current link seems to 404, but this page https://campusgroups.rit.edu/fsl/about/ seems to have the relevant information.