### PR TITLE
Futureproof copyright year in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,7 +35,7 @@
                     <a href="mailto:webmaster@csh.rit.edu">webmaster@csh.rit.edu</a>
                 </div>
                 <div class="col-12 col-lg-4">
-                    &copy; 2020 Computer Science House
+                    &copy; {{ site.time | date: '%Y' }} Computer Science House
                 </div>
                 <div class="text-md-right col-12 col-lg-4">
                     <a href="https://github.com/computersciencehouse/cshpublicsite">


### PR DESCRIPTION
This PR makes the copyright year in the footer reflect the current year (the year of the latest build).

Maybe fixes #270? (Not exactly sure what #270 means as it's a big vague.)