### PR TITLE
Update environment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,14 @@ RUN bundle install
 
 COPY . /site/
 
+ENV CSHPUBSITE_ASSETS_URL="https://assets.csh.rit.edu/pubsite"
+ENV CSHPUBSITE_S3_URL="https://s3.csh.rit.edu"
+
 RUN bundle exec rake build:production 
 
 FROM docker.io/galenguyer/nginx:1.21.6-alpine-spa
 
 RUN rm -rf /usr/share/nginx/html/*
 COPY --from=builder /site/_site/ /usr/share/nginx/html/
+
 


### PR DESCRIPTION
Hotfix for docker container environments - namely okd. I'm certain there is a way to access external env vars from within the docker container's executive space but I am too lazy right now to solve it. If we ever get a backup server setup, the dockerfile could be modified directly or the potential aforementioned external env var accessing could be implemented.
