### PR TITLE
Blog posts should no longer expand outside of viewport on small screens

### DIFF
--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -1,4 +1,5 @@
 .post {
+    display: block; // attempt at fixing https://github.com/ComputerScienceHouse/CSHPublicSite/issues/331
     img {
         max-width: 100%;
         margin: 20px 0;


### PR DESCRIPTION
An attempt at fixing: https://github.com/ComputerScienceHouse/CSHPublicSite/issues/331