### PR TITLE
Updated paragraph about how to apply to link to the application

### DIFF
--- a/membership/intro-process.html
+++ b/membership/intro-process.html
@@ -10,8 +10,10 @@ active: membership-intro
             <div class="col-12">
                 <h2 class="header">Applying to CSH</h2>
                 <p class="long-form">
-                    Incoming Freshman can apply through their RIT Housing Applications, when asked about Special Interest Houses.
-                    Current students can either visit us on the 3rd floor of Fredericka Douglass Sprague Perry Hall, or <a href="/contact/">contact our Evaluations Director</a> to grab a physical application to fill out.
+                    Incoming Freshman can apply through their RIT Housing Application, when asked about Special Interest Houses.
+                    Current students can either visit us on the 3rd floor of Fredericka Douglass Sprague Perry Hall, or submit a
+                    completed <a href="https://application.csh.rit.edu">application</a> to our <a href="/contact/">Evaluations Director</a>
+                    by emailing the filled out document to <a href="mailto:evals@csh.rit.edu">evals@csh.rit.edu</a>
                 </p>
 
                 <p class="long-form">Note that RIT Housing caps us at 50 acceptances every summer, so if you weren't accepted at first, feel free to re-apply at any time!</p>


### PR DESCRIPTION
Paragraph about how to apply still said that current students should pick up a physical application from the evals director, so I updated it to link to the application document and listed the evals email address so it is easy to see where to submit it to