### PR TITLE
Fix Datadog warning

### DIFF
--- a/httpd-suffix.conf
+++ b/httpd-suffix.conf
@@ -1,3 +1,4 @@
+AddDefaultCharset utf-8
 LoadModule userdir_module modules/mod_userdir.so
 UserDir public_html
 <Directory />


### PR DESCRIPTION
Make apache return `text/html; charset=UTF-8` instead of `text/html`