### PR TITLE
Remove "One Project per Freshman" from projects page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,5 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 
 gem "rake", "~> 12.3"
+
+gem "json", "~> 2.7"

--- a/Gemfile
+++ b/Gemfile
@@ -34,5 +34,3 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 
 gem "rake", "~> 12.3"
-
-gem "json", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,6 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.7.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.7.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -80,6 +81,7 @@ DEPENDENCIES
   jekyll-environment-variables
   jekyll-feed (~> 0.6)
   jekyll-regex-replace
+  json (~> 2.7)
   liquid-md5
   minima (~> 2.5)
   rake (~> 12.3)

--- a/about/projects.html
+++ b/about/projects.html
@@ -71,27 +71,6 @@ active: about-projects
         </p>
       </div>
     </div>
-
-    <div class="row spaced">
-      <div class="col-12 col-lg-3">
-          <picture>
-              <source srcset="{{site.env.CSHPUBSITE_ASSETS_URL}}/projects/oppf.webp" type="image/webp" />
-              <source srcset="{{site.env.CSHPUBSITE_ASSETS_URL}}/projects/oppf.jpg" type="image/jpeg" />
-              <img class="rounded" src="{{site.env.CSHPUBSITE_ASSETS_URL}}/projects/oppf.jpg" alt="One Project Per Freshman, in which CSH freshmen are provided free hardware for projects" />
-          </picture>
-      </div>
-      <div class="col-12 col-lg-9">
-        <h2>One Project Per Freshman</h2>
-        <p class="long-form">
-          One Project Per Freshman looks to put the necessary tools in the hands
-          of freshman to enable them to learn more about hardware electronics
-          projects without a financial investment on their part. In its current
-          form, incoming freshman members are given the choice between a
-          Raspberry Pi or an Arduino with a starter kit to tinker with
-          throughout the year.
-        </p>
-      </div>
-    </div>
     <div class="row spaced">
       <div class="col-12 col-lg-3">
           <picture>


### PR DESCRIPTION
Remove "One Project per Freshman" from the projects page as it is no longer in practice.